### PR TITLE
feature/use_hex_encoding

### DIFF
--- a/mocket/async_mocket.py
+++ b/mocket/async_mocket.py
@@ -7,11 +7,17 @@ async def wrapper(
     truesocket_recording_dir=None,
     strict_mode=False,
     strict_mode_allowed=None,
+    use_hex_encoding=True,
     *args,
     **kwargs,
 ):
     async with Mocketizer.factory(
-        test, truesocket_recording_dir, strict_mode, strict_mode_allowed, args
+        test,
+        truesocket_recording_dir,
+        strict_mode,
+        strict_mode_allowed,
+        use_hex_encoding,
+        args,
     ):
         return await test(*args, **kwargs)
 

--- a/mocket/inject.py
+++ b/mocket/inject.py
@@ -41,6 +41,7 @@ true_urllib3_match_hostname = urllib3_match_hostname
 def enable(
     namespace: str | None = None,
     truesocket_recording_dir: str | None = None,
+    use_hex_encoding=True,
 ) -> None:
     from mocket.mocket import Mocket
     from mocket.socket import MocketSocket, create_connection, socketpair
@@ -48,6 +49,7 @@ def enable(
 
     Mocket._namespace = namespace
     Mocket._truesocket_recording_dir = truesocket_recording_dir
+    Mocket._use_hex_encoding = use_hex_encoding
 
     if truesocket_recording_dir and not os.path.isdir(truesocket_recording_dir):
         # JSON dumps will be saved here

--- a/mocket/mocket.py
+++ b/mocket/mocket.py
@@ -22,6 +22,7 @@ class Mocket:
     _requests: ClassVar[list] = []
     _namespace: ClassVar[str] = str(id(_entries))
     _truesocket_recording_dir: ClassVar[str | None] = None
+    _use_hex_encoding: ClassVar[bool] = True
 
     enable = mocket.inject.enable
     disable = mocket.inject.disable
@@ -95,6 +96,10 @@ class Mocket:
     @classmethod
     def get_truesocket_recording_dir(cls) -> str | None:
         return cls._truesocket_recording_dir
+
+    @classmethod
+    def get_use_hex_encoding(cls) -> bool:
+        return cls._use_hex_encoding
 
     @classmethod
     def assert_fail_if_entries_not_served(cls) -> None:

--- a/mocket/mocketizer.py
+++ b/mocket/mocketizer.py
@@ -9,6 +9,7 @@ class Mocketizer:
         instance=None,
         namespace=None,
         truesocket_recording_dir=None,
+        use_hex_encoding=True,
         strict_mode=False,
         strict_mode_allowed=None,
     ):
@@ -57,7 +58,14 @@ class Mocketizer:
             method()
 
     @staticmethod
-    def factory(test, truesocket_recording_dir, strict_mode, strict_mode_allowed, args):
+    def factory(
+        test,
+        truesocket_recording_dir,
+        strict_mode,
+        strict_mode_allowed,
+        use_hex_encoding,
+        args,
+    ):
         instance = args[0] if args else None
         namespace = None
         if truesocket_recording_dir:
@@ -74,6 +82,7 @@ class Mocketizer:
             namespace=namespace,
             truesocket_recording_dir=truesocket_recording_dir,
             strict_mode=strict_mode,
+            use_hex_encoding=use_hex_encoding,
             strict_mode_allowed=strict_mode_allowed,
         )
 
@@ -83,11 +92,17 @@ def wrapper(
     truesocket_recording_dir=None,
     strict_mode=False,
     strict_mode_allowed=None,
+    use_hex_encoding=True,
     *args,
     **kwargs,
 ):
     with Mocketizer.factory(
-        test, truesocket_recording_dir, strict_mode, strict_mode_allowed, args
+        test,
+        truesocket_recording_dir,
+        strict_mode,
+        strict_mode_allowed,
+        use_hex_encoding,
+        args,
     ):
         return test(*args, **kwargs)
 

--- a/mocket/mocketizer.py
+++ b/mocket/mocketizer.py
@@ -15,6 +15,7 @@ class Mocketizer:
     ):
         self.instance = instance
         self.truesocket_recording_dir = truesocket_recording_dir
+        self.use_hex_encoding = use_hex_encoding
         self.namespace = namespace or str(id(self))
         MocketMode().STRICT = strict_mode
         if strict_mode:
@@ -28,6 +29,7 @@ class Mocketizer:
         Mocket.enable(
             namespace=self.namespace,
             truesocket_recording_dir=self.truesocket_recording_dir,
+            use_hex_encoding=self.use_hex_encoding,
         )
         if self.instance:
             self.check_and_call("mocketize_setup")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -118,15 +118,14 @@ class TrueHttpEntryTestCase(HttpTestCase):
             truesocket_recording_dir=temp_dir, use_hex_encoding=False
         ):
             url = "http://httpbin.local/gzip"
+            headers = {
+                "Accept-Encoding": "gzip, deflate, zstd",
+            }
 
-            requests.get(url)
-            resp = requests.get(
+            requests.get(
                 url,
-                headers={
-                    "Accept-Encoding": "gzip, deflate, zstd",
-                },
+                headers=headers,
             )
-            self.assertEqual(resp.status_code, 200)
 
             dump_filename = os.path.join(
                 Mocket.get_truesocket_recording_dir(),
@@ -136,9 +135,15 @@ class TrueHttpEntryTestCase(HttpTestCase):
             with open(dump_filename) as f:
                 responses = json.load(f)
 
-        for _, value in responses["httpbin.local"]["80"].items():
-            self.assertIn("HTTP/1.1 200", value["response"])
-            self.assertIn("gzip, deflate, zstd", value["response"])
+            for _, value in responses["httpbin.local"]["80"].items():
+                self.assertIn("HTTP/1.1 200", value["response"])
+                self.assertIn("gzip, deflate, zstd", value["response"])
+
+            resp = requests.get(
+                url,
+                headers=headers,
+            )
+            self.assertEqual(resp.status_code, 200)
 
     @mocketize
     def test_wrongpath_truesendall(self):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -55,6 +55,30 @@ class TrueHttpEntryTestCase(HttpTestCase):
 
         self.assertEqual(len(responses["httpbin.local"]["80"].keys()), 2)
 
+    def test_truesendall_with_recording_without_hex_encoding(self):
+        with tempfile.TemporaryDirectory() as temp_dir, Mocketizer(
+            truesocket_recording_dir=temp_dir, use_hex_encoding=False
+        ):
+            url = "http://httpbin.local/ip"
+
+            urlopen(url)
+            requests.get(url)
+            resp = urlopen(url)
+            self.assertEqual(resp.code, 200)
+            resp = requests.get(url)
+            self.assertEqual(resp.status_code, 200)
+            assert "origin" in resp.json()
+
+            dump_filename = os.path.join(
+                Mocket.get_truesocket_recording_dir(),
+                Mocket.get_namespace() + ".json",
+            )
+            with open(dump_filename) as f:
+                responses = json.load(f)
+
+        for _, value in responses["httpbin.local"]["80"].items():
+            self.assertIn("HTTP/1.1 200", value["response"])
+
     def test_truesendall_with_gzip_recording(self):
         with tempfile.TemporaryDirectory() as temp_dir, Mocketizer(
             truesocket_recording_dir=temp_dir


### PR DESCRIPTION
- This pull requests adds the option to disable hex-encoding of the recording in the response.
- The reasoning for this feature is to be able to save the recordings in human-readable form
- The human readable form of the recordings allows easy review of new mocks and hand-tuning them to cover a wider variaty of cases when used with interceptors such as pook